### PR TITLE
Tweaks now that I can see it in place

### DIFF
--- a/src/dom7.d.ts
+++ b/src/dom7.d.ts
@@ -1,4 +1,4 @@
-export interface Dom7 {
+interface Dom7 {
     length: number;
 
     /**  Retrieve one of the elements matched by the Dom7 object (jQuery syntax). **/
@@ -274,6 +274,65 @@ export interface Dom7 {
     resize(handler : (event : Event) => void) : Dom7;
     /** Add "scroll" event handler to collection */
     scroll(handler : (event : Event) => void) : Dom7;
+}
+
+export interface Dom7AjaxSettings {
+    /** Request url */
+    url?: string;
+    /** Request method (e.g. "POST", "GET", "PUT") */
+    method?: string;
+    /** A function to be called if the request succeeds */
+    success?: Function;
+    /** A pre-request callback function that can be used to modify the XHR object before it is sent. Use this to set custom headers, etc */
+    beforeSend?: Function;
+    /** A function to be called if the request fails */
+    error?: Function;
+    /** A function to be called when the request finishes (after success and error callbacks are executed) */
+    complete?: Function;
+    /** If you need synchronous requests, set this option to `false` */
+    async?: boolean;
+    /** If set to false, it will force requested pages not to be cached by the browser. Setting cache to false will only work correctly with HEAD and GET requests. It works by appending "_nocache={timestamp}" to the GET parameters */
+    cache?: boolean;
+    /** Content type. Also could be 'multipart/form-data' and 'text/plain'. For cross-domain requests, setting the content type to anything other than application/x-www-form-urlencoded, multipart/form-data, or text/plain will trigger the browser to send a preflight OPTIONS request to the server */
+    contentType?: any;
+    /** If you wish to force a crossDomain request (such as JSONP) on the same domain, set the value of crossDomain to true. When true additional "X-Requested-With: XMLHttpRequest" header will be added to request */
+    crossDomain?: boolean;
+    /** Data to be sent to the server. It is converted to a query string, if not already a string. It's appended to the url for GET-requests. See processData option to prevent this automatic processing. For POST requests could be `FormData` type */
+    data?: any;
+    /** By default, data passed in to the data option as an object (technically, anything other than a string) will be processed and transformed into a query string, fitting to the default content-type "application/x-www-form-urlencoded". If you want to send a DOMDocument, or other non-processed data, set this option to `false` */
+    processData?: boolean;
+    /** The type of data that you're expecting back from the server. Could be 'text' or 'json' */
+    dataType?: string;
+    /** An object of additional header key/value pairs to send along with requests using the XMLHttpRequest transport */
+    headers?: { [key: string]: any; };
+    /** An object of fieldName-fieldValue pairs to set on the native XHR object */
+    xhrFields?: { [key: string]: any; };
+    /** A username to be used with XMLHttpRequest in response to an HTTP access authentication request */
+    username?: string;
+    /** A password to be used with XMLHttpRequest in response to an HTTP access authentication request */
+    password?: string;
+    /** Set a timeout (in milliseconds) for the request */
+    timeout?: number;
+}
+
+export interface Dom7XHR extends XMLHttpRequest {
+    /** Object with passed XHR request parameters */
+    requestParameters?: any;
+    /** String with request URL */
+    requestUrl?: string;
+}
+
+export interface DomAjaxSettings {
+    /** A pre-request callback function that can be used to modify the XHR object before it is sent. Use this to set custom headers, etc */
+    beforeSend? (jqXHR: Dom7XHR, settings: DomAjaxSettings): any;
+    /** A function to be called if the request fails */
+    error? (jqXHR: Dom7XHR, textStatus: string, errorThrown: string): any;
+    /** A function to be called if the request succeeds */
+    success? (data: any, textStatus: string, jqXHR: Dom7XHR): any;
+    /** A function to be called when the request finishes (after success and error callbacks are executed) */
+    complete? (jqXHR: Dom7XHR, textStatus: string): any;
+    /** An object of numeric HTTP codes and functions to be called when the response has the corresponding code. For example, the following will alert when the response status is a 404 */
+    statusCode?: { [key: string]: any; };
 }
 
 export interface Dom7Static


### PR DESCRIPTION
1) The default export doesn't need to be also a named export.
2) Somehow the `Dom7AjaxSettings`, `Dom7XHR `, and `DomAjaxSettings ` got dropped.  Was that me or did you remove them because they're obsolete?  I deleted my branch to investigate, but anyway I think they're necessary because `Dom7XHR` is expected by formAjaxSuccess in F7 Core, right?