### PR TITLE
Add "browser" field to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.1.3",
   "description": "Minimalistic JavaScript library for DOM manipulation, with a jQuery-compatible API",
   "main": "dist/dom7.js",
+  "browser": "dist/dom7.js",
   "types": "dist/dom7.d.ts",
   "jsnext:main": "dist/dom7.module.js",
   "module": "dist/dom7.module.js",


### PR DESCRIPTION
When bundling the Swiper module using Webpack, the bundled js will cause a Syntax error in IE 11.

The reason is that Webpack will use the "module" field (since the default value of mainFields defined in Webpack is ["browser", "module", "main"] ) as the entry point of Swiper.

As the class syntax inside the "module" entry point was not transpiled and then was bundled into the target js files, which will cause the Syntax error in IE 11, because IE 11 doesn't support the class syntax.

The relevant issue is #21 