### PR TITLE
TypeScript: Add missing animate method definition

### DIFF
--- a/src/dom7.d.ts
+++ b/src/dom7.d.ts
@@ -274,6 +274,10 @@ export interface Dom7Instance {
     resize(handler : (event : Event) => void) : Dom7Instance;
     /** Add "scroll" event handler to collection */
     scroll(handler : (event : Event) => void) : Dom7Instance;
+
+    // Animation
+    /** Perform a custom animation of a set of CSS properties */
+    animate(properties: any, parameters: any) : Dom7Instance;
 }
 
 export interface Dom7


### PR DESCRIPTION
The [animate method](https://framework7.io/docs/dom7.html#animation) is missing in [dom7.d.ts](https://github.com/Rogerrrrrrrs/dom7/blob/master/src/dom7.d.ts) TypeScript definitions.