### PR TITLE
Export package.json

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -8,6 +8,7 @@
   "main": "./dom7.esm.js",
   "module": "./dom7.esm.js",
   "exports": {
+    "./package.json": "./package.json",
     ".": "./dom7.esm.js"
   },
   "repository": {


### PR DESCRIPTION
Some build tools try to read the `package.json` and it creates issues if it's not exported