### PR TITLE
typing: fix multiple class definitions on class manipulation methods

### DIFF
--- a/src/dom7.d.ts
+++ b/src/dom7.d.ts
@@ -133,13 +133,13 @@ export interface Dom7Array {
 
   // CLASSES
   /** Add one or more classes to elements */
-  addClass(...className: string): Dom7Array;
+  addClass(...className: string[]): Dom7Array;
   /** Remove one or more specified classes */
-  removeClass(...className: string): Dom7Array;
+  removeClass(...className: string[]): Dom7Array;
   /** Determine whether any of the matched elements are assigned the given classes */
-  hasClass(...className: string): Dom7Array;
+  hasClass(...className: string[]): Dom7Array;
   /** Remove (if class is present) or add (if not) one or more classes from each element in the set of matched elements */
-  toggleClass(...className: string): Dom7Array;
+  toggleClass(...className: string[]): Dom7Array;
 
   // ATTRIBUTES AND PROPERTIES
   /** Get property value */


### PR DESCRIPTION
Seems like https://github.com/nolimits4web/dom7/commit/3ba73d5dcf69e793186d28aefd29304e73b0bf00 accidentally introduced a typing problem:

![image](https://user-images.githubusercontent.com/1052079/216282163-d76dc6c7-4b34-4816-8e49-5b9e12c1a2fe.png)

With these changes, the problem goes away again 😅 