### PR TITLE
Add the types condition to the package.json#exports

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -8,8 +8,16 @@
   "main": "./dom7.esm.js",
   "module": "./dom7.esm.js",
   "exports": {
-    "./package.json": "./package.json",
-    ".": "./dom7.esm.js"
+    ".": {
+      "import": {
+        "default": "./dom7.esm.js",
+        "types": "./dom7.d.ts"
+      },
+      "require": {
+        "default": "./dom7.js",
+        "types": "./dom7.d.ts"
+      }
+    }
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is required for TypeScript to work with packages that have exports when using the new moduleResolution: node16/nodenext/bundler settings. When those are not used then TypeScript just ignores package.json#exports - but when you make it aware of exports by using those options then it requires the types to be included in exports and not as the top-level key of package.json